### PR TITLE
IntLikeMap: Improve the type of compose

### DIFF
--- a/src/IntLike/Map.hs
+++ b/src/IntLike/Map.hs
@@ -411,7 +411,7 @@ disjoint :: forall x a b. IntLikeMap x a -> IntLikeMap x b -> Bool
 disjoint = coerce (IntMap.disjoint @a @b)
 {-# INLINE disjoint #-}
 
-compose :: forall x c. IntLikeMap x c -> IntMap Int -> IntLikeMap x c
+compose :: forall x a c. (Coercible x Int) => IntLikeMap x c -> IntLikeMap a x -> IntLikeMap a c
 compose = coerce (IntMap.compose @c)
 {-# INLINE compose #-}
 


### PR DESCRIPTION
Apologies for following up with this right after you released #2 to Hackage!

I missed the type signature of the second argument to `compose`, which should also be an `IntLikeMap`, rather than `IntMap Int`.