### PR TITLE
Support GHC 9.10 / base 4.20 (`foldl'` migration)

### DIFF
--- a/src/IntLike/Graph.hs
+++ b/src/IntLike/Graph.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module IntLike.Graph
   ( IntLikeGraph (..)
   , adjacencyIntMultiMap
@@ -16,7 +18,9 @@ import qualified Algebra.Graph.AdjacencyIntMap.Algorithm as AIMA
 import Algebra.Graph.Class (Graph (..))
 import Control.DeepSeq (NFData)
 import Data.Coerce (Coercible, coerce)
+#if !MIN_VERSION_base(4,20,0) /* foldl' migration */
 import Data.Foldable (foldl')
+#endif
 import Data.Hashable (Hashable)
 import Data.Tuple (swap)
 import IntLike.Equiv (IntLikeEquiv)

--- a/src/IntLike/Map.hs
+++ b/src/IntLike/Map.hs
@@ -184,7 +184,17 @@ import Data.Coerce (Coercible, coerce)
 import Data.IntMap.Strict (IntMap)
 import qualified Data.IntMap.Strict as IntMap
 import IntLike.Set (IntLikeSet (..))
-import Prelude hiding (filter, foldl, foldr, lookup, map, null)
+import Prelude hiding
+  ( filter
+  , foldl
+#if MIN_VERSION_base(4,20,0) /* foldl' migration */
+  , foldl'
+#endif
+  , foldr
+  , lookup
+  , map
+  , null
+  )
 
 type role IntLikeMap nominal representational
 

--- a/src/IntLike/MultiMap.hs
+++ b/src/IntLike/MultiMap.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module IntLike.MultiMap
   ( IntLikeMultiMap
   , empty
@@ -13,7 +15,9 @@ where
 
 import Control.Monad (foldM)
 import Data.Coerce (Coercible)
+#if !MIN_VERSION_base(4,20,0) /* foldl' migration */
 import Data.Foldable (foldl')
+#endif
 import IntLike.Map (IntLikeMap)
 import qualified IntLike.Map as ILM
 import IntLike.Set (IntLikeSet)

--- a/src/IntLike/Set.hs
+++ b/src/IntLike/Set.hs
@@ -113,7 +113,17 @@ import qualified Data.IntSet as IntSet
 #if MIN_VERSION_containers(0,8,0)
 import Data.List.NonEmpty (NonEmpty)
 #endif
-import Prelude hiding (filter, foldMap, foldl, foldr, map, null)
+import Prelude hiding
+  ( filter
+  , foldMap
+  , foldl
+#if MIN_VERSION_base(4,20,0) /* foldl' migration */
+  , foldl'
+#endif
+  , foldr
+  , map
+  , null
+  )
 
 type role IntLikeSet nominal
 


### PR DESCRIPTION
Details:

- https://github.com/haskell/core-libraries-committee/blob/main/guides/export-foldl-prime-prelude.md